### PR TITLE
chore(deps): faça downgrade para versões mínimas suportadas pelo Joomla

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=6.1-php8.4-apache
+ARG VARIANT=6.1-php8.3-apache
 FROM joomla:${VARIANT}
 
 # Install goodies

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -31,7 +31,7 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
-    image: mariadb:12.0
+    image: mariadb:10.6
     deploy:
       resources:
         limits:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "config": {
     "optimize-autoloader": true,
     "platform": {
-      "php": "8.4.0"
+      "php": "8.3.0"
     }
   },
   "authors": [
@@ -20,7 +20,7 @@
     }
   ],
   "require": {
-    "php": "^8.4.0"
+    "php": "^8.3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.95",


### PR DESCRIPTION
Isso é necessário para manter compatibilidade com a versão mínima exigida pelo Joomla 6.1.